### PR TITLE
Initialize Feedstock

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  melody_org: flask-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: flask-update
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e5cbaa31169f0060348ad5ca0191027e5f1f41f3f27fdeef208365e09c55eb9a
 
 build:
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,16 +10,18 @@ source:
   sha256: e5cbaa31169f0060348ad5ca0191027e5f1f41f3f27fdeef208365e09c55eb9a
 
 build:
-  noarch: python
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - pytest >=4.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - pytest --cov pytest_describe
 
 about:
-  home: https://github.com/ropez/pytest-describe
+  home: https://github.com/pytest-dev/pytest-describe
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -45,6 +45,8 @@ about:
   description: |
     pytest-describe is a plugin for pytest that allows tests to be written in arbitrary
     nested describe-blocks, similar to RSpec (Ruby) and Jasmine (JavaScript).
+  dev_url: https://github.com/pytest-dev/pytest-describe
+  doc_url: https://github.com/pytest-dev/pytest-describe/blob/main/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
   imports:
     - pytest_describe
   commands:
-    - python -m pip check
+    - pip check
     - pytest --cov pytest_describe
 
 about:


### PR DESCRIPTION
This was on Anaconda Recipes but no submodule had been made.

Needed for graphql-core, which is needed for Moto 4.0.8, which is part of the werkzeug/flask suite.

Jira ticket: https://anaconda.atlassian.net/browse/PKG-596
Upstream repo: https://github.com/pytest-dev/pytest-describe
Changelog: https://github.com/pytest-dev/pytest-describe/releases