### PR TITLE
pytest-describe 2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
     pytest-describe is a plugin for pytest that allows tests to be written in arbitrary
     nested describe-blocks, similar to RSpec (Ruby) and Jasmine (JavaScript).
   dev_url: https://github.com/pytest-dev/pytest-describe
-  doc_url: https://github.com/pytest-dev/pytest-describe/blob/main/README.rst
+  doc_url: https://github.com/pytest-dev/pytest-describe/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-describe" %}
-{% set version = "2.0.1" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e5cbaa31169f0060348ad5ca0191027e5f1f41f3f27fdeef208365e09c55eb9a
+  sha256: 39bb05eb90f2497d9ca342ef9a0b7fa5bada7e58505aec33f66d661d631955b7
 
 build:
   skip: True  # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True  # [py<36]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 39bb05eb90f2497d9ca342ef9a0b7fa5bada7e58505aec33f66d661d631955b7
 
 build:
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -22,7 +22,7 @@ requirements:
     - wheel
   run:
     - python
-    - pytest >=4.0.0
+    - pytest >=4.6,<9
 
 test:
   requires:


### PR DESCRIPTION
pytest-describe 2.2.0 (updated to latest for py312 support)

**Destination channel:** {defaults}

### Links

- [PKG-4725](https://anaconda.atlassian.net/browse/PKG-4725) 
- [Upstream repository](https://github.com/pytest-dev/pytest-describe/tree/2.2.0)
- Relevant dependency PRs:
  - `mlflow` -> `graphene` -> `graphql-relay` -> `pytest-describe`

### Explanation of changes:

- Updated to latest


[PKG-4725]: https://anaconda.atlassian.net/browse/PKG-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ